### PR TITLE
Add test resources management

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -38,12 +38,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 11
+  serializedVersion: 12
   m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
@@ -94,10 +94,11 @@ LightmapSettings:
     m_PVRFilteringAtrousPositionSigmaDirect: 0.5
     m_PVRFilteringAtrousPositionSigmaIndirect: 2
     m_PVRFilteringAtrousPositionSigmaAO: 1
-    m_ShowResolutionOverlay: 1
     m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
   m_LightingDataAsset: {fileID: 0}
-  m_UseShadowmask: 1
+  m_LightingSettings: {fileID: 0}
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -117,6 +118,8 @@ NavMeshSettings:
     manualTileSize: 0
     tileSize: 256
     accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
@@ -145,8 +148,9 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 705507993}
   m_Enabled: 1
-  serializedVersion: 9
+  serializedVersion: 10
   m_Type: 1
+  m_Shape: 0
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
   m_Range: 10
@@ -161,6 +165,24 @@ Light:
     m_Bias: 0.05
     m_NormalBias: 0.4
     m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
   m_Cookie: {fileID: 0}
   m_DrawHalo: 0
   m_Flare: {fileID: 0}
@@ -175,6 +197,9 @@ Light:
   m_BounceIntensity: 1
   m_ColorTemperature: 6570
   m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &705507995

--- a/Assets/Settings.meta
+++ b/Assets/Settings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2b3b7e5e1b17e4b409fb7a2b8c40bee1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Settings/Resources.meta
+++ b/Assets/Settings/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 684fa7f996fa9a249ad0bfd0e664b093
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Settings/Resources/UGF.Testing.meta
+++ b/Assets/Settings/Resources/UGF.Testing.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10a5be482ccb7c644ac4ffb181d26c98
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Settings/Resources/UGF.Testing/TestResourcesSettings.asset
+++ b/Assets/Settings/Resources/UGF.Testing/TestResourcesSettings.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a2e762924b4b0c4090f809ee6310363, type: 3}
+  m_Name: TestResourcesSettings
+  m_EditorClassIdentifier: 
+  m_assetBundleDirectory: 1
+  m_assetBundlePath: Testing/TestResources

--- a/Assets/Settings/Resources/UGF.Testing/TestResourcesSettings.asset.meta
+++ b/Assets/Settings/Resources/UGF.Testing/TestResourcesSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0bfa4c275551482468e2658825c989d6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets.meta
+++ b/Assets/StreamingAssets.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dd79a4d581df7d243bfae8ada62583e8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/Dummy.meta
+++ b/Assets/StreamingAssets/Dummy.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6e895fb0c25ddc645af5e0bb0beb7f90
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Testing.Runtime.Tests/TestResources.meta
+++ b/Assets/UGF.Testing.Runtime.Tests/TestResources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1edb0694f4d4f8148a60668ffaf479a8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder0.meta
+++ b/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder0.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b6b815f187c750647a0fbdc234156991
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder0/Nested.meta
+++ b/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder0/Nested.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0f2f8dc2042c74140b5ea2335294e2ac
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder0/Nested/TestMaterial.mat
+++ b/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder0/Nested/TestMaterial.mat
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: TestMaterial
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0, g: 1, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder0/Nested/TestMaterial.mat.meta
+++ b/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder0/Nested/TestMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 581eb39651fce334d9c695fb10f85893
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder0/TestMaterial.mat
+++ b/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder0/TestMaterial.mat
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: TestMaterial
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0, g: 0, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder0/TestMaterial.mat.meta
+++ b/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder0/TestMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 452f4f4e8c97a4c4ca5443abc92e67ef
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder1.meta
+++ b/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder1.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f093776faefb4884f853ec27c05017ec
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder1/TestMaterial.mat
+++ b/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder1/TestMaterial.mat
@@ -1,0 +1,79 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: TestMaterial
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 0, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder1/TestMaterial.mat.meta
+++ b/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder1/TestMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ed8da41e5feeb8845b6ed08b1b4b635c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Testing.Runtime.Tests/TestResources/TestTestResources.cs
+++ b/Assets/UGF.Testing.Runtime.Tests/TestResources/TestTestResources.cs
@@ -1,0 +1,47 @@
+﻿using NUnit.Framework;
+using UGF.Testing.Runtime.TestResources;
+using UnityEngine;
+
+namespace UGF.Testing.Runtime.Tests.TestResources
+{
+    public class TestTestResources
+    {
+        [Test]
+        public void HasAssetBundleLoaded()
+        {
+            bool result = TestResourcesProvider.Handler.HasAssetBundle;
+
+            Assert.True(result);
+        }
+
+        [Test]
+        public void LoadBlue()
+        {
+            var result = TestResourcesProvider.Load<Material>("Folder0/TestMaterial");
+
+            Assert.NotNull(result);
+            Assert.AreEqual("TestMaterial", result.name);
+            Assert.AreEqual(Color.blue, result.color);
+        }
+
+        [Test]
+        public void LoadRed()
+        {
+            var result = TestResourcesProvider.Load<Material>("Folder1/TestMaterial");
+
+            Assert.NotNull(result);
+            Assert.AreEqual("TestMaterial", result.name);
+            Assert.AreEqual(Color.red, result.color);
+        }
+
+        [Test]
+        public void LoadGreen()
+        {
+            var result = TestResourcesProvider.Load<Material>("Folder0/Nested/TestMaterial");
+
+            Assert.NotNull(result);
+            Assert.AreEqual("TestMaterial", result.name);
+            Assert.AreEqual(Color.green, result.color);
+        }
+    }
+}

--- a/Assets/UGF.Testing.Runtime.Tests/TestResources/TestTestResources.cs.meta
+++ b/Assets/UGF.Testing.Runtime.Tests/TestResources/TestTestResources.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c9fc4a17f848176448f01b2ccb43760d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Testing.Runtime.Tests/UGF.Testing.Runtime.Tests.Tests.asmdef
+++ b/Assets/UGF.Testing.Runtime.Tests/UGF.Testing.Runtime.Tests.Tests.asmdef
@@ -1,7 +1,9 @@
 {
     "name": "UGF.Testing.Runtime.Tests.Tests",
+    "rootNamespace": "",
     "references": [
         "GUID:caf53a88a5f705b469991beeab5f32d0",
+        "GUID:9b24bb9684a1ac744ba842cf8de9fc0f",
         "GUID:27619889b8ba8c24980f49ee34dbb44a"
     ],
     "includePlatforms": [],
@@ -12,8 +14,7 @@
         "nunit.framework.dll"
     ],
     "autoReferenced": true,
-    "defineConstraints": [
-        "UNITY_INCLUDE_TESTS"
-    ],
-    "versionDefines": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/UGF.Testing.Runtime.Tests/UGF.Testing.Runtime.Tests.Tests.asmdef
+++ b/Assets/UGF.Testing.Runtime.Tests/UGF.Testing.Runtime.Tests.Tests.asmdef
@@ -14,7 +14,9 @@
         "nunit.framework.dll"
     ],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": [],
     "noEngineReferences": false
 }

--- a/Packages/UGF.Testing/Editor.meta
+++ b/Packages/UGF.Testing/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3d10b48522c682a4db1c4f92bd0561e9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UGF.Testing/Editor/TestResources.meta
+++ b/Packages/UGF.Testing/Editor/TestResources.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 56f61e563d2942c680c9862041cb8773
+timeCreated: 1628267684

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorBuildPostprocessor.cs
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorBuildPostprocessor.cs
@@ -1,0 +1,22 @@
+﻿using UGF.Testing.Editor.Editor.TestResources;
+using UnityEditor.TestTools;
+using UnityEngine.TestTools;
+
+[assembly: PostBuildCleanup(typeof(TestResourcesEditorBuildPostprocessor))]
+
+namespace UGF.Testing.Editor.Editor.TestResources
+{
+    [RequirePlatformSupport]
+    internal class TestResourcesEditorBuildPostprocessor : IPostBuildCleanup
+    {
+        public void Cleanup()
+        {
+            TestResourcesEditorSettingsData settings = TestResourcesEditorSettings.Settings.GetData();
+
+            if (settings.ClearAfterTestsPlayerBuild)
+            {
+                TestResourcesEditorUtility.ClearAssetBundle();
+            }
+        }
+    }
+}

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorBuildPostprocessor.cs
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorBuildPostprocessor.cs
@@ -13,7 +13,7 @@ namespace UGF.Testing.Editor.Editor.TestResources
         {
             TestResourcesEditorSettingsData settings = TestResourcesEditorSettings.Settings.GetData();
 
-            if (settings.ClearAfterTestsPlayerBuild)
+            if (settings.ClearAfterTestRun)
             {
                 TestResourcesEditorUtility.ClearAssetBundle();
             }

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorBuildPostprocessor.cs.meta
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorBuildPostprocessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a2415a10620dc1d4dabe73758d2dfddf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorBuildPreprocessor.cs
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorBuildPreprocessor.cs
@@ -13,7 +13,7 @@ namespace UGF.Testing.Editor.Editor.TestResources
         {
             TestResourcesEditorSettingsData settings = TestResourcesEditorSettings.Settings.GetData();
 
-            if (settings.BuildOnTestsPlayerBuild)
+            if (settings.BuildBeforeTestRun)
             {
                 TestResourcesEditorUtility.BuildAssetBundle();
             }

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorBuildPreprocessor.cs
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorBuildPreprocessor.cs
@@ -1,0 +1,22 @@
+﻿using UGF.Testing.Editor.Editor.TestResources;
+using UnityEditor.TestTools;
+using UnityEngine.TestTools;
+
+[assembly: PrebuildSetup(typeof(TestResourcesEditorBuildPreprocessor))]
+
+namespace UGF.Testing.Editor.Editor.TestResources
+{
+    [RequirePlatformSupport]
+    internal class TestResourcesEditorBuildPreprocessor : IPrebuildSetup
+    {
+        public void Setup()
+        {
+            TestResourcesEditorSettingsData settings = TestResourcesEditorSettings.Settings.GetData();
+
+            if (settings.BuildOnTestsPlayerBuild)
+            {
+                TestResourcesEditorUtility.BuildAssetBundle();
+            }
+        }
+    }
+}

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorBuildPreprocessor.cs.meta
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorBuildPreprocessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f76a9a546ba78b04295e8816be702d52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettings.cs
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettings.cs
@@ -1,0 +1,40 @@
+﻿using System.IO;
+using UGF.CustomSettings.Editor;
+using UGF.RuntimeTools.Runtime.Storage;
+using UnityEditor;
+
+namespace UGF.Testing.Editor.Editor.TestResources
+{
+    public static class TestResourcesEditorSettings
+    {
+        public static CustomSettingsEditorPackage<TestResourcesEditorSettingsData> Settings { get; } = new CustomSettingsEditorPackage<TestResourcesEditorSettingsData>
+        (
+            "UGF.Testing",
+            nameof(TestResourcesEditorSettings)
+        );
+
+        public static string GetAssetBundlePath()
+        {
+            TestResourcesEditorSettingsData data = Settings.GetData();
+            string path = StorageUtility.GetPath(data.AssetBundleOutputDirectory, data.AssetBundleOutputPath);
+
+            path = Path.Combine(path, data.AssetBundleName);
+
+            return path;
+        }
+
+        public static string GetAssetBundleOutputPath()
+        {
+            TestResourcesEditorSettingsData data = Settings.GetData();
+            string path = StorageUtility.GetPath(data.AssetBundleOutputDirectory, data.AssetBundleOutputPath);
+
+            return path;
+        }
+
+        [SettingsProvider]
+        private static SettingsProvider GetProvider()
+        {
+            return new CustomSettingsProvider<TestResourcesEditorSettingsData>("Project/Unity Game Framework/Test Resources Editor", Settings, SettingsScope.Project);
+        }
+    }
+}

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettings.cs.meta
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f888730769759c4b8df494e7d62b7ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsData.cs
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsData.cs
@@ -8,16 +8,16 @@ namespace UGF.Testing.Editor.Editor.TestResources
 {
     public class TestResourcesEditorSettingsData : CustomSettingsData
     {
-        [SerializeField] private bool m_buildOnTestsPlayerBuild = true;
-        [SerializeField] private bool m_clearAfterTestsPlayerBuild = true;
+        [SerializeField] private bool m_buildBeforeTestRun = true;
+        [SerializeField] private bool m_clearAfterTestRun = true;
         [SerializeField] private string m_assetBundleName = "TestResources";
         [SerializeField] private BuildAssetBundleOptions m_assetBundleOptions = BuildAssetBundleOptions.None;
         [SerializeField] private StoragePathType m_assetBundleOutputDirectory = StoragePathType.StreamingAssets;
         [SerializeField] private string m_assetBundleOutputPath = "Testing";
         [SerializeField] private List<string> m_folders = new List<string>();
 
-        public bool BuildOnTestsPlayerBuild { get { return m_buildOnTestsPlayerBuild; } set { m_buildOnTestsPlayerBuild = value; } }
-        public bool ClearAfterTestsPlayerBuild { get { return m_clearAfterTestsPlayerBuild; } set { m_clearAfterTestsPlayerBuild = value; } }
+        public bool BuildBeforeTestRun { get { return m_buildBeforeTestRun; } set { m_buildBeforeTestRun = value; } }
+        public bool ClearAfterTestRun { get { return m_clearAfterTestRun; } set { m_clearAfterTestRun = value; } }
         public string AssetBundleName { get { return m_assetBundleName; } set { m_assetBundleName = value; } }
         public BuildAssetBundleOptions AssetBundleOptions { get { return m_assetBundleOptions; } set { m_assetBundleOptions = value; } }
         public StoragePathType AssetBundleOutputDirectory { get { return m_assetBundleOutputDirectory; } set { m_assetBundleOutputDirectory = value; } }

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsData.cs
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsData.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using UGF.CustomSettings.Runtime;
+using UGF.RuntimeTools.Runtime.Storage;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.Testing.Editor.Editor.TestResources
+{
+    public class TestResourcesEditorSettingsData : CustomSettingsData
+    {
+        [SerializeField] private bool m_buildOnTestsPlayerBuild = true;
+        [SerializeField] private bool m_clearAfterTestsPlayerBuild = true;
+        [SerializeField] private string m_assetBundleName = "TestResources";
+        [SerializeField] private BuildAssetBundleOptions m_assetBundleOptions = BuildAssetBundleOptions.None;
+        [SerializeField] private StoragePathType m_assetBundleOutputDirectory = StoragePathType.StreamingAssets;
+        [SerializeField] private string m_assetBundleOutputPath = "Testing";
+        [SerializeField] private List<string> m_folders = new List<string>();
+
+        public bool BuildOnTestsPlayerBuild { get { return m_buildOnTestsPlayerBuild; } set { m_buildOnTestsPlayerBuild = value; } }
+        public bool ClearAfterTestsPlayerBuild { get { return m_clearAfterTestsPlayerBuild; } set { m_clearAfterTestsPlayerBuild = value; } }
+        public string AssetBundleName { get { return m_assetBundleName; } set { m_assetBundleName = value; } }
+        public BuildAssetBundleOptions AssetBundleOptions { get { return m_assetBundleOptions; } set { m_assetBundleOptions = value; } }
+        public StoragePathType AssetBundleOutputDirectory { get { return m_assetBundleOutputDirectory; } set { m_assetBundleOutputDirectory = value; } }
+        public string AssetBundleOutputPath { get { return m_assetBundleOutputPath; } set { m_assetBundleOutputPath = value; } }
+        public List<string> Folders { get { return m_folders; } }
+    }
+}

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsData.cs.meta
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1181af8b76ce6ad499d843bf0c8ffd47
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataEditor.cs
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataEditor.cs
@@ -1,0 +1,75 @@
+﻿using UGF.EditorTools.Editor.IMGUI.Scopes;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.Testing.Editor.Editor.TestResources
+{
+    [CustomEditor(typeof(TestResourcesEditorSettingsData), true)]
+    internal class TestResourcesEditorSettingsDataEditor : UnityEditor.Editor
+    {
+        private SerializedProperty m_propertyBuildOnTestsPlayerBuild;
+        private SerializedProperty m_propertyClearAfterTestsPlayerBuild;
+        private SerializedProperty m_propertyAssetBundleName;
+        private SerializedProperty m_propertyAssetBundleOptions;
+        private SerializedProperty m_propertyAssetBundleOutputDirectory;
+        private SerializedProperty m_propertyAssetBundleOutputPath;
+        private TestResourcesEditorSettingsDataFolderListDrawer m_listFolders;
+
+        private void OnEnable()
+        {
+            m_propertyBuildOnTestsPlayerBuild = serializedObject.FindProperty("m_buildOnTestsPlayerBuild");
+            m_propertyClearAfterTestsPlayerBuild = serializedObject.FindProperty("m_clearAfterTestsPlayerBuild");
+            m_propertyAssetBundleName = serializedObject.FindProperty("m_assetBundleName");
+            m_propertyAssetBundleOptions = serializedObject.FindProperty("m_assetBundleOptions");
+            m_propertyAssetBundleOutputDirectory = serializedObject.FindProperty("m_assetBundleOutputDirectory");
+            m_propertyAssetBundleOutputPath = serializedObject.FindProperty("m_assetBundleOutputPath");
+
+            m_listFolders = new TestResourcesEditorSettingsDataFolderListDrawer(serializedObject.FindProperty("m_folders"));
+            m_listFolders.Enable();
+        }
+
+        private void OnDisable()
+        {
+            m_listFolders.Disable();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            using (new SerializedObjectUpdateScope(serializedObject))
+            {
+                EditorGUILayout.PropertyField(m_propertyBuildOnTestsPlayerBuild);
+                EditorGUILayout.PropertyField(m_propertyClearAfterTestsPlayerBuild);
+                EditorGUILayout.PropertyField(m_propertyAssetBundleName);
+                EditorGUILayout.PropertyField(m_propertyAssetBundleOptions);
+                EditorGUILayout.PropertyField(m_propertyAssetBundleOutputDirectory);
+                EditorGUILayout.PropertyField(m_propertyAssetBundleOutputPath);
+
+                m_listFolders.DrawGUILayout();
+            }
+
+            EditorGUILayout.Space();
+
+            using (new EditorGUILayout.HorizontalScope())
+            {
+                GUILayout.FlexibleSpace();
+
+                using (new EditorGUI.DisabledScope(!TestResourcesEditorUtility.IsAssetBundleExists()))
+                {
+                    if (GUILayout.Button("Clear", GUILayout.Width(75F)))
+                    {
+                        TestResourcesEditorUtility.ClearAssetBundle();
+                        AssetDatabase.Refresh();
+                    }
+                }
+
+                if (GUILayout.Button("Build", GUILayout.Width(75F)))
+                {
+                    TestResourcesEditorUtility.BuildAssetBundle();
+                    AssetDatabase.Refresh();
+                }
+
+                EditorGUILayout.Space();
+            }
+        }
+    }
+}

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataEditor.cs
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataEditor.cs
@@ -62,10 +62,13 @@ namespace UGF.Testing.Editor.Editor.TestResources
                     }
                 }
 
-                if (GUILayout.Button("Build", GUILayout.Width(75F)))
+                using (new EditorGUI.DisabledScope(m_listFolders.SerializedProperty.arraySize == 0))
                 {
-                    TestResourcesEditorUtility.BuildAssetBundle();
-                    AssetDatabase.Refresh();
+                    if (GUILayout.Button("Build", GUILayout.Width(75F)))
+                    {
+                        TestResourcesEditorUtility.BuildAssetBundle();
+                        AssetDatabase.Refresh();
+                    }
                 }
 
                 EditorGUILayout.Space();

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataEditor.cs
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataEditor.cs
@@ -1,4 +1,6 @@
-﻿using UGF.EditorTools.Editor.IMGUI.Scopes;
+﻿using System.IO;
+using UGF.AssetBundles.Editor;
+using UGF.EditorTools.Editor.IMGUI.Scopes;
 using UnityEditor;
 using UnityEngine;
 
@@ -7,6 +9,7 @@ namespace UGF.Testing.Editor.Editor.TestResources
     [CustomEditor(typeof(TestResourcesEditorSettingsData), true)]
     internal class TestResourcesEditorSettingsDataEditor : UnityEditor.Editor
     {
+        private readonly AssetBundleFileDrawer m_assetBundleDrawer = new AssetBundleFileDrawer();
         private SerializedProperty m_propertyBuildBeforeTestRun;
         private SerializedProperty m_propertyClearAfterTestRun;
         private SerializedProperty m_propertyAssetBundleName;
@@ -14,9 +17,13 @@ namespace UGF.Testing.Editor.Editor.TestResources
         private SerializedProperty m_propertyAssetBundleOutputDirectory;
         private SerializedProperty m_propertyAssetBundleOutputPath;
         private TestResourcesEditorSettingsDataFolderListDrawer m_listFolders;
+        private bool m_displayAssetBundleInfo;
 
         private void OnEnable()
         {
+            m_assetBundleDrawer.DisplayMenuClear = false;
+            m_assetBundleDrawer.Enable();
+
             m_propertyBuildBeforeTestRun = serializedObject.FindProperty("m_buildBeforeTestRun");
             m_propertyClearAfterTestRun = serializedObject.FindProperty("m_clearAfterTestRun");
             m_propertyAssetBundleName = serializedObject.FindProperty("m_assetBundleName");
@@ -26,10 +33,13 @@ namespace UGF.Testing.Editor.Editor.TestResources
 
             m_listFolders = new TestResourcesEditorSettingsDataFolderListDrawer(serializedObject.FindProperty("m_folders"));
             m_listFolders.Enable();
+
+            UpdateAssetBundleDrawer();
         }
 
         private void OnDisable()
         {
+            m_assetBundleDrawer.Disable();
             m_listFolders.Disable();
         }
 
@@ -49,16 +59,24 @@ namespace UGF.Testing.Editor.Editor.TestResources
 
             EditorGUILayout.Space();
 
+            bool exists = TestResourcesEditorUtility.IsAssetBundleExists();
+
             using (new EditorGUILayout.HorizontalScope())
             {
                 GUILayout.FlexibleSpace();
 
-                using (new EditorGUI.DisabledScope(!TestResourcesEditorUtility.IsAssetBundleExists()))
+                m_displayAssetBundleInfo = GUILayout.Toggle(m_displayAssetBundleInfo, "Display AssetBundle Information");
+
+                EditorGUILayout.Space();
+
+                using (new EditorGUI.DisabledScope(!exists))
                 {
                     if (GUILayout.Button("Clear", GUILayout.Width(75F)))
                     {
                         TestResourcesEditorUtility.ClearAssetBundle();
                         AssetDatabase.Refresh();
+
+                        UpdateAssetBundleDrawer();
                     }
                 }
 
@@ -68,10 +86,38 @@ namespace UGF.Testing.Editor.Editor.TestResources
                     {
                         TestResourcesEditorUtility.BuildAssetBundle();
                         AssetDatabase.Refresh();
+
+                        UpdateAssetBundleDrawer();
                     }
                 }
 
                 EditorGUILayout.Space();
+            }
+
+            EditorGUILayout.Space();
+
+            if (m_displayAssetBundleInfo)
+            {
+                if (m_assetBundleDrawer.HasData)
+                {
+                    m_assetBundleDrawer.DrawGUILayout();
+                }
+                else
+                {
+                    EditorGUILayout.HelpBox("No AssetBundle information available, build required.", MessageType.Info);
+                }
+            }
+        }
+
+        private void UpdateAssetBundleDrawer()
+        {
+            m_assetBundleDrawer.Clear();
+
+            string path = TestResourcesEditorSettings.GetAssetBundlePath();
+
+            if (File.Exists(path))
+            {
+                m_assetBundleDrawer.Set(path);
             }
         }
     }

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataEditor.cs
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataEditor.cs
@@ -7,8 +7,8 @@ namespace UGF.Testing.Editor.Editor.TestResources
     [CustomEditor(typeof(TestResourcesEditorSettingsData), true)]
     internal class TestResourcesEditorSettingsDataEditor : UnityEditor.Editor
     {
-        private SerializedProperty m_propertyBuildOnTestsPlayerBuild;
-        private SerializedProperty m_propertyClearAfterTestsPlayerBuild;
+        private SerializedProperty m_propertyBuildBeforeTestRun;
+        private SerializedProperty m_propertyClearAfterTestRun;
         private SerializedProperty m_propertyAssetBundleName;
         private SerializedProperty m_propertyAssetBundleOptions;
         private SerializedProperty m_propertyAssetBundleOutputDirectory;
@@ -17,8 +17,8 @@ namespace UGF.Testing.Editor.Editor.TestResources
 
         private void OnEnable()
         {
-            m_propertyBuildOnTestsPlayerBuild = serializedObject.FindProperty("m_buildOnTestsPlayerBuild");
-            m_propertyClearAfterTestsPlayerBuild = serializedObject.FindProperty("m_clearAfterTestsPlayerBuild");
+            m_propertyBuildBeforeTestRun = serializedObject.FindProperty("m_buildBeforeTestRun");
+            m_propertyClearAfterTestRun = serializedObject.FindProperty("m_clearAfterTestRun");
             m_propertyAssetBundleName = serializedObject.FindProperty("m_assetBundleName");
             m_propertyAssetBundleOptions = serializedObject.FindProperty("m_assetBundleOptions");
             m_propertyAssetBundleOutputDirectory = serializedObject.FindProperty("m_assetBundleOutputDirectory");
@@ -37,8 +37,8 @@ namespace UGF.Testing.Editor.Editor.TestResources
         {
             using (new SerializedObjectUpdateScope(serializedObject))
             {
-                EditorGUILayout.PropertyField(m_propertyBuildOnTestsPlayerBuild);
-                EditorGUILayout.PropertyField(m_propertyClearAfterTestsPlayerBuild);
+                EditorGUILayout.PropertyField(m_propertyBuildBeforeTestRun);
+                EditorGUILayout.PropertyField(m_propertyClearAfterTestRun);
                 EditorGUILayout.PropertyField(m_propertyAssetBundleName);
                 EditorGUILayout.PropertyField(m_propertyAssetBundleOptions);
                 EditorGUILayout.PropertyField(m_propertyAssetBundleOutputDirectory);

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataEditor.cs.meta
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b72be49c6e5d369408f1e417f0338651
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataFolderListDrawer.cs
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataFolderListDrawer.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using UGF.EditorTools.Editor.IMGUI;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.Testing.Editor.Editor.TestResources
+{
+    internal class TestResourcesEditorSettingsDataFolderListDrawer : ReorderableListDrawer
+    {
+        private Styles m_styles;
+
+        private class Styles
+        {
+            public GUIContent ButtonContent { get; } = new GUIContent(EditorGUIUtility.FindTexture("_Menu"));
+            public GUIStyle ButtonStyle { get; } = new GUIStyle("IconButton");
+        }
+
+        public TestResourcesEditorSettingsDataFolderListDrawer(SerializedProperty serializedProperty) : base(serializedProperty)
+        {
+        }
+
+        protected override void OnDrawGUI(Rect position, GUIContent label = null)
+        {
+            m_styles ??= new Styles();
+
+            base.OnDrawGUI(position, label);
+        }
+
+        protected override void OnDrawElementContent(Rect position, SerializedProperty serializedProperty, int index, bool isActive, bool isFocused)
+        {
+            float height = EditorGUIUtility.singleLineHeight;
+            float space = EditorGUIUtility.standardVerticalSpacing;
+
+            var rectPath = new Rect(position.x, position.y, position.width - height - space, position.height);
+            var rectButton = new Rect(rectPath.xMax + space, position.y, height, position.height);
+
+            EditorGUI.PropertyField(rectPath, serializedProperty, GUIContent.none);
+
+            if (GUI.Button(rectButton, m_styles.ButtonContent, m_styles.ButtonStyle))
+            {
+                serializedProperty.stringValue = SelectPath(serializedProperty.stringValue);
+                serializedProperty.serializedObject.ApplyModifiedProperties();
+            }
+        }
+
+        protected override float OnElementHeightContent(SerializedProperty serializedProperty, int index)
+        {
+            return EditorGUIUtility.singleLineHeight;
+        }
+
+        private string SelectPath(string path)
+        {
+            string directory = Environment.CurrentDirectory;
+            string selected = EditorUtility.OpenFolderPanel("Select Folder", "Assets", string.Empty);
+
+            if (!string.IsNullOrEmpty(selected))
+            {
+                selected = selected.Substring(directory.Length + 1, selected.Length - directory.Length - 1);
+
+                path = selected;
+            }
+
+            return path;
+        }
+    }
+}

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataFolderListDrawer.cs.meta
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataFolderListDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 03345d6f7bcef2147ac242f24429c531
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorUtility.cs
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorUtility.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using UGF.AssetBundles.Editor;
+using UnityEditor;
+using UnityEngine;
+
+namespace UGF.Testing.Editor.Editor.TestResources
+{
+    public static class TestResourcesEditorUtility
+    {
+        public static AssetBundleManifest BuildAssetBundle()
+        {
+            return BuildAssetBundle(EditorUserBuildSettings.activeBuildTarget);
+        }
+
+        public static AssetBundleManifest BuildAssetBundle(BuildTarget buildTarget)
+        {
+            TestResourcesEditorSettingsData settings = TestResourcesEditorSettings.Settings.GetData();
+            AssetBundleBuildInfo build = GetAssetBundleBuildInfo(settings.AssetBundleName, settings.Folders);
+            string outputPath = TestResourcesEditorSettings.GetAssetBundleOutputPath();
+
+            return AssetBundleBuildUtility.Build(new[] { build }, outputPath, buildTarget, settings.AssetBundleOptions);
+        }
+
+        public static bool IsAssetBundleExists()
+        {
+            string path = TestResourcesEditorSettings.GetAssetBundlePath();
+
+            return File.Exists(path);
+        }
+
+        public static void ClearAssetBundle()
+        {
+            string outputPath = TestResourcesEditorSettings.GetAssetBundleOutputPath();
+            string metaPath = $"{outputPath}.meta";
+
+            if (Directory.Exists(outputPath))
+            {
+                Directory.Delete(outputPath, true);
+            }
+
+            if (File.Exists(metaPath))
+            {
+                File.Delete(metaPath);
+            }
+        }
+
+        public static AssetBundleBuildInfo GetAssetBundleBuildInfo(string assetBundleName, IReadOnlyList<string> folders)
+        {
+            if (string.IsNullOrEmpty(assetBundleName)) throw new ArgumentException("Value cannot be null or empty.", nameof(assetBundleName));
+            if (folders == null) throw new ArgumentNullException(nameof(folders));
+
+            var assets = new Dictionary<string, string>();
+
+            GetAssets(assets, folders);
+
+            var info = new AssetBundleBuildInfo(assetBundleName);
+
+            foreach (KeyValuePair<string, string> pair in assets)
+            {
+                info.AddAsset(pair.Key, pair.Value);
+            }
+
+            return info;
+        }
+
+        public static void GetAssets(IDictionary<string, string> assets, IReadOnlyList<string> folders)
+        {
+            if (assets == null) throw new ArgumentNullException(nameof(assets));
+            if (folders == null) throw new ArgumentNullException(nameof(folders));
+
+            for (int i = 0; i < folders.Count; i++)
+            {
+                string folderPath = folders[i];
+                string[] guids = AssetDatabase.FindAssets(string.Empty, new[] { folderPath });
+
+                foreach (string guid in guids)
+                {
+                    string assetPath = AssetDatabase.GUIDToAssetPath(guid);
+                    string addressRoot = Path.GetDirectoryName(folderPath);
+
+                    string addressPath = !string.IsNullOrEmpty(addressRoot)
+                        ? assetPath.Substring(addressRoot.Length + 1, assetPath.Length - addressRoot.Length - 1)
+                        : assetPath;
+
+                    string addressName = Path.GetFileNameWithoutExtension(addressPath);
+                    string addressDirectory = Path.GetDirectoryName(addressPath);
+                    string address = !string.IsNullOrEmpty(addressDirectory) ? $"{addressDirectory}/{addressName}" : addressName;
+
+                    address = address.Replace('\\', '/');
+
+                    assets.Add(address, assetPath);
+                }
+            }
+        }
+    }
+}

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorUtility.cs
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorUtility.cs
@@ -20,6 +20,8 @@ namespace UGF.Testing.Editor.Editor.TestResources
             AssetBundleBuildInfo build = GetAssetBundleBuildInfo(settings.AssetBundleName, settings.Folders);
             string outputPath = TestResourcesEditorSettings.GetAssetBundleOutputPath();
 
+            Directory.CreateDirectory(outputPath);
+
             return AssetBundleBuildUtility.Build(new[] { build }, outputPath, buildTarget, settings.AssetBundleOptions);
         }
 

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorUtility.cs.meta
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 85b70e2351931e24286fb20737de0aaa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesSettingsProvider.cs
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesSettingsProvider.cs
@@ -1,0 +1,15 @@
+﻿using UGF.CustomSettings.Editor;
+using UGF.Testing.Runtime.TestResources;
+using UnityEditor;
+
+namespace UGF.Testing.Editor.Editor.TestResources
+{
+    internal static class TestResourcesSettingsProvider
+    {
+        [SettingsProvider]
+        private static SettingsProvider GetProvider()
+        {
+            return new CustomSettingsProvider<TestResourcesSettingsAsset>("Project/Unity Game Framework/Test Resources", TestResourcesSettings.Settings, SettingsScope.Project);
+        }
+    }
+}

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesSettingsProvider.cs.meta
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesSettingsProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e12386cfa1ec78542a0661d2e1ce1db8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UGF.Testing/Editor/UGF.Testing.Editor.asmdef
+++ b/Packages/UGF.Testing/Editor/UGF.Testing.Editor.asmdef
@@ -1,0 +1,25 @@
+{
+    "name": "UGF.Testing.Editor",
+    "rootNamespace": "UGF.Testing.Editor",
+    "references": [
+        "GUID:caf53a88a5f705b469991beeab5f32d0",
+        "GUID:ff62901452104d14cae29322ac133c05",
+        "GUID:4806a292f99efd44aba38aea20847e17",
+        "GUID:a0dc2e2425360fc479b77a028f0e9225",
+        "GUID:16fde9420ef50f34db61e711e19381dd",
+        "GUID:abdd615e45137c74ca2ce9c636c78c15",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Packages/UGF.Testing/Editor/UGF.Testing.Editor.asmdef.meta
+++ b/Packages/UGF.Testing/Editor/UGF.Testing.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c764336314e8e584e84ebc0396eab4fd
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UGF.Testing/Runtime/TestResources.meta
+++ b/Packages/UGF.Testing/Runtime/TestResources.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 716c9a4c4948414aa0ed2d6c1ca99475
+timeCreated: 1628266027

--- a/Packages/UGF.Testing/Runtime/TestResources/TestResourcesProvider.cs
+++ b/Packages/UGF.Testing/Runtime/TestResources/TestResourcesProvider.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using UGF.AssetBundles.Runtime;
+using UGF.RuntimeTools.Runtime.Tasks;
+using Object = UnityEngine.Object;
+
+namespace UGF.Testing.Runtime.TestResources
+{
+    public static class TestResourcesProvider
+    {
+        public static AssetBundleHandler Handler { get; }
+
+        static TestResourcesProvider()
+        {
+            string path = TestResourcesSettings.GetAssetBundlePath();
+
+            Handler = new AssetBundleHandler(path);
+
+            if (File.Exists(Handler.Path))
+            {
+                Handler.Load();
+            }
+        }
+
+        public static T Load<T>(string path) where T : Object
+        {
+            return (T)Load(path, typeof(T));
+        }
+
+        public static Object Load(string path, Type type)
+        {
+            if (string.IsNullOrEmpty(path)) throw new ArgumentException("Value cannot be null or empty.", nameof(path));
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
+            Object asset = Handler.AssetBundle.LoadAsset(path, type);
+
+            return asset ? asset : throw new ArgumentException($"Asset not found by the specified path and type: '{path}', '{type}'.");
+        }
+
+        public static async Task<T> LoadAsync<T>(string path) where T : Object
+        {
+            return (T)await LoadAsync(path, typeof(T));
+        }
+
+        public static async Task<object> LoadAsync(string path, Type type)
+        {
+            if (string.IsNullOrEmpty(path)) throw new ArgumentException("Value cannot be null or empty.", nameof(path));
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
+            Object asset = await Handler.AssetBundle.LoadAssetAsync(path, type).WaitAsync();
+
+            return asset ? asset : throw new ArgumentException($"Asset not found by the specified path and type: '{path}', '{type}'.");
+        }
+    }
+}

--- a/Packages/UGF.Testing/Runtime/TestResources/TestResourcesProvider.cs.meta
+++ b/Packages/UGF.Testing/Runtime/TestResources/TestResourcesProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c07424b4cb97b674387fe141c11b95da
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UGF.Testing/Runtime/TestResources/TestResourcesSettings.cs
+++ b/Packages/UGF.Testing/Runtime/TestResources/TestResourcesSettings.cs
@@ -1,0 +1,22 @@
+﻿using UGF.CustomSettings.Runtime;
+using UGF.RuntimeTools.Runtime.Storage;
+
+namespace UGF.Testing.Runtime.TestResources
+{
+    public static class TestResourcesSettings
+    {
+        public static CustomSettingsPackage<TestResourcesSettingsAsset> Settings { get; } = new CustomSettingsPackage<TestResourcesSettingsAsset>
+        (
+            "UGF.Testing",
+            nameof(TestResourcesSettings)
+        );
+
+        public static string GetAssetBundlePath()
+        {
+            TestResourcesSettingsAsset data = Settings.GetData();
+            string path = StorageUtility.GetPath(data.AssetBundleDirectory, data.AssetBundlePath);
+
+            return path;
+        }
+    }
+}

--- a/Packages/UGF.Testing/Runtime/TestResources/TestResourcesSettings.cs.meta
+++ b/Packages/UGF.Testing/Runtime/TestResources/TestResourcesSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bfeb8793e1d9aff4bbd87974862732e0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UGF.Testing/Runtime/TestResources/TestResourcesSettingsAsset.cs
+++ b/Packages/UGF.Testing/Runtime/TestResources/TestResourcesSettingsAsset.cs
@@ -1,0 +1,15 @@
+﻿using UGF.CustomSettings.Runtime;
+using UGF.RuntimeTools.Runtime.Storage;
+using UnityEngine;
+
+namespace UGF.Testing.Runtime.TestResources
+{
+    public class TestResourcesSettingsAsset : CustomSettingsData
+    {
+        [SerializeField] private StoragePathType m_assetBundleDirectory = StoragePathType.StreamingAssets;
+        [SerializeField] private string m_assetBundlePath = "Testing/TestResources";
+
+        public StoragePathType AssetBundleDirectory { get { return m_assetBundleDirectory; } set { m_assetBundleDirectory = value; } }
+        public string AssetBundlePath { get { return m_assetBundlePath; } set { m_assetBundlePath = value; } }
+    }
+}

--- a/Packages/UGF.Testing/Runtime/TestResources/TestResourcesSettingsAsset.cs.meta
+++ b/Packages/UGF.Testing/Runtime/TestResources/TestResourcesSettingsAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a2e762924b4b0c4090f809ee6310363
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/UGF.Testing/Runtime/UGF.Testing.Runtime.asmdef
+++ b/Packages/UGF.Testing/Runtime/UGF.Testing.Runtime.asmdef
@@ -2,6 +2,9 @@
     "name": "UGF.Testing.Runtime",
     "rootNamespace": "UGF.Testing.Runtime",
     "references": [
+        "GUID:9b24bb9684a1ac744ba842cf8de9fc0f",
+        "GUID:ff62901452104d14cae29322ac133c05",
+        "GUID:16fde9420ef50f34db61e711e19381dd",
         "GUID:27619889b8ba8c24980f49ee34dbb44a"
     ],
     "includePlatforms": [],

--- a/Packages/UGF.Testing/package.json
+++ b/Packages/UGF.Testing/package.json
@@ -19,6 +19,8 @@
     "registry": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
   },
   "dependencies": {
-    "com.unity.test-framework": "1.1.27"
+    "com.unity.test-framework": "1.1.27",
+    "com.ugf.customsettings": "3.4.1",
+    "com.ugf.assetbundles": "1.0.0-preview"
   }
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,11 +1,48 @@
 {
   "dependencies": {
+    "com.ugf.assetbundles": {
+      "version": "1.0.0-preview",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.assetbundle": "1.0.0",
+        "com.ugf.editortools": "1.12.0",
+        "com.ugf.runtimetools": "2.3.0"
+      },
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
+    },
+    "com.ugf.customsettings": {
+      "version": "3.4.1",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.ugf.editortools": "1.7.0"
+      },
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
+    },
+    "com.ugf.editortools": {
+      "version": "1.12.0",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
+    },
+    "com.ugf.runtimetools": {
+      "version": "2.3.0",
+      "depth": 2,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://unitygameframework.jfrog.io/artifactory/api/npm/default"
+    },
     "com.ugf.testing": {
       "version": "file:UGF.Testing",
       "depth": 0,
       "source": "embedded",
       "dependencies": {
-        "com.unity.test-framework": "1.1.27"
+        "com.unity.test-framework": "1.1.27",
+        "com.ugf.customsettings": "3.4.1",
+        "com.ugf.assetbundles": "1.0.0-preview"
       }
     },
     "com.unity.ext.nunit": {
@@ -34,6 +71,12 @@
         "com.unity.modules.jsonserialize": "1.0.0"
       },
       "url": "https://packages.unity.com"
+    },
+    "com.unity.modules.assetbundle": {
+      "version": "1.0.0",
+      "depth": 2,
+      "source": "builtin",
+      "dependencies": {}
     },
     "com.unity.modules.imgui": {
       "version": "1.0.0",

--- a/ProjectSettings/Packages/UGF.Testing/TestResourcesEditorSettings.asset
+++ b/ProjectSettings/Packages/UGF.Testing/TestResourcesEditorSettings.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1181af8b76ce6ad499d843bf0c8ffd47, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_buildOnTestsPlayerBuild: 1
-  m_clearAfterTestsPlayerBuild: 1
+  m_buildBeforeTestRun: 1
+  m_clearAfterTestRun: 1
   m_assetBundleName: TestResources
   m_assetBundleOptions: 0
   m_assetBundleOutputDirectory: 1

--- a/ProjectSettings/Packages/UGF.Testing/TestResourcesEditorSettings.asset
+++ b/ProjectSettings/Packages/UGF.Testing/TestResourcesEditorSettings.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1181af8b76ce6ad499d843bf0c8ffd47, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_buildOnTestsPlayerBuild: 1
+  m_clearAfterTestsPlayerBuild: 1
+  m_assetBundleName: TestResources
+  m_assetBundleOptions: 0
+  m_assetBundleOutputDirectory: 1
+  m_assetBundleOutputPath: Testing
+  m_folders: []

--- a/ProjectSettings/Packages/UGF.Testing/TestResourcesEditorSettings.asset
+++ b/ProjectSettings/Packages/UGF.Testing/TestResourcesEditorSettings.asset
@@ -18,4 +18,6 @@ MonoBehaviour:
   m_assetBundleOptions: 0
   m_assetBundleOutputDirectory: 1
   m_assetBundleOutputPath: Testing
-  m_folders: []
+  m_folders:
+  - Assets/UGF.Testing.Runtime.Tests/TestResources/Folder0
+  - Assets/UGF.Testing.Runtime.Tests/TestResources/Folder1


### PR DESCRIPTION
- Update dependencies: add `com.ugf.customsettings` of `3.4.1` version and `com.ugf.assetbundles` of `1.0.0-preview` version.
- Add `TestResourcesProvider` class to access to _AssetBundle_ with testing resources during runtime tests.
- Add _Test Resources_ runtime settings to specify settings for _AssetBundle_ loading for runtime tests.
- Add _Test Resources Editor_ editor settings to specify what resources to build as _AssetBundle_ which used during tests.
- Add `TestResourcesEditorUtility` class to manage _AssetBundle_ for testing resources in editor.