### PR TITLE
Change preview assetbundle info to update only when required

### DIFF
--- a/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder2.meta
+++ b/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder2.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aa2d32ab7e143994f8b69f065e241ff3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder2/TestPrefab.prefab
+++ b/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder2/TestPrefab.prefab
@@ -1,0 +1,45 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8111434762736129404
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4634672990646705139}
+  - component: {fileID: 8440403392530801223}
+  m_Layer: 0
+  m_Name: TestPrefab
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4634672990646705139
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8111434762736129404}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8440403392530801223
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8111434762736129404}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0977df9b973c4ca58a9097ca8503862c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder2/TestPrefab.prefab.meta
+++ b/Assets/UGF.Testing.Runtime.Tests/TestResources/Folder2/TestPrefab.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7bc9b41e4acd3874c85f9011b3e20472
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UGF.Testing.Runtime.Tests/TestResources/TestResourcesComponent1.cs
+++ b/Assets/UGF.Testing.Runtime.Tests/TestResources/TestResourcesComponent1.cs
@@ -1,0 +1,8 @@
+﻿using UnityEngine;
+
+namespace UGF.Testing.Runtime.Tests.TestResources
+{
+    public class TestResourcesComponent1 : MonoBehaviour
+    {
+    }
+}

--- a/Assets/UGF.Testing.Runtime.Tests/TestResources/TestResourcesComponent1.cs.meta
+++ b/Assets/UGF.Testing.Runtime.Tests/TestResources/TestResourcesComponent1.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0977df9b973c4ca58a9097ca8503862c
+timeCreated: 1628351138

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataEditor.cs
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataEditor.cs
@@ -33,8 +33,6 @@ namespace UGF.Testing.Editor.Editor.TestResources
 
             m_listFolders = new TestResourcesEditorSettingsDataFolderListDrawer(serializedObject.FindProperty("m_folders"));
             m_listFolders.Enable();
-
-            UpdateAssetBundleDrawer();
         }
 
         private void OnDisable()
@@ -65,7 +63,12 @@ namespace UGF.Testing.Editor.Editor.TestResources
             {
                 GUILayout.FlexibleSpace();
 
-                m_displayAssetBundleInfo = GUILayout.Toggle(m_displayAssetBundleInfo, "Display AssetBundle Information");
+                if (GUILayout.Toggle(m_displayAssetBundleInfo, "Display AssetBundle Information") != m_displayAssetBundleInfo)
+                {
+                    m_displayAssetBundleInfo = !m_displayAssetBundleInfo;
+
+                    UpdateAssetBundleDrawer();
+                }
 
                 EditorGUILayout.Space();
 

--- a/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataEditor.cs
+++ b/Packages/UGF.Testing/Editor/TestResources/TestResourcesEditorSettingsDataEditor.cs
@@ -116,11 +116,14 @@ namespace UGF.Testing.Editor.Editor.TestResources
         {
             m_assetBundleDrawer.Clear();
 
-            string path = TestResourcesEditorSettings.GetAssetBundlePath();
-
-            if (File.Exists(path))
+            if (m_displayAssetBundleInfo)
             {
-                m_assetBundleDrawer.Set(path);
+                string path = TestResourcesEditorSettings.GetAssetBundlePath();
+
+                if (File.Exists(path))
+                {
+                    m_assetBundleDrawer.Set(path);
+                }
             }
         }
     }

--- a/Packages/UGF.Testing/package.json
+++ b/Packages/UGF.Testing/package.json
@@ -21,6 +21,6 @@
   "dependencies": {
     "com.unity.test-framework": "1.1.27",
     "com.ugf.customsettings": "3.4.1",
-    "com.ugf.assetbundles": "1.0.0-preview"
+    "com.ugf.assetbundles": "1.0.0-preview.1"
   }
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.ugf.assetbundles": {
-      "version": "1.0.0-preview",
+      "version": "1.0.0-preview.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -42,7 +42,7 @@
       "dependencies": {
         "com.unity.test-framework": "1.1.27",
         "com.ugf.customsettings": "3.4.1",
-        "com.ugf.assetbundles": "1.0.0-preview"
+        "com.ugf.assetbundles": "1.0.0-preview.1"
       }
     },
     "com.unity.ext.nunit": {

--- a/ProjectSettings/Packages/UGF.Testing/TestResourcesEditorSettings.asset
+++ b/ProjectSettings/Packages/UGF.Testing/TestResourcesEditorSettings.asset
@@ -21,3 +21,4 @@ MonoBehaviour:
   m_folders:
   - Assets/UGF.Testing.Runtime.Tests/TestResources/Folder0
   - Assets/UGF.Testing.Runtime.Tests/TestResources/Folder1
+  - Assets/UGF.Testing.Runtime.Tests/TestResources/Folder2


### PR DESCRIPTION
- Update dependencies: `com.ugf.assetbundles` to `1.0.0-preview.1` version.
- Change _Test Resources Editor settings AssetBundle Information_ update only when required.